### PR TITLE
make buildFreeType public

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ fn thisDir() []const u8 {
     return std.fs.path.dirname(@src().file) orelse ".";
 }
 
-fn buildFreeType(b: *std.build.Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget, root_path: []const u8, custom_config_path: ?[]const u8) !*std.build.LibExeObjStep {
+pub fn buildFreeType(b: *std.build.Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget, root_path: []const u8, custom_config_path: ?[]const u8) !*std.build.LibExeObjStep {
     const main_abs = try std.fs.path.join(b.allocator, &.{ root_path, "src/base/ftbase.c" });
     const include_path = try std.fs.path.join(b.allocator, &.{ root_path, "include" });
     defer b.allocator.free(main_abs);


### PR DESCRIPTION
I successfully imported zig-freetype today in a project and rendered a letter! Woohoo!

However I had to make `buildFreeType` public to use it from my own build.zig.

Note: I'm not sure `lib.install()` should be in `buildFreeType`. I was able to use the library even if the install step was in the `build` function. The name of `install` suggests it has side effects and my (uninformed) guess is that it shouldn't be in `buildFreeType`.